### PR TITLE
Changed special chance to 1/10k

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,4 +4,4 @@
 frequency: 10
 
 # ????
-special_chance: 0.001
+special_chance: 0.0001


### PR DESCRIPTION
The special occurrence happened three times in 1.25k messages; yes, statistics and all, but the chance should be reduced down to keep it from spamming unnecessarily